### PR TITLE
feat: Parse anyOf and ignore null.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ const { typeName, typeDefinitions } = getGraphqlFromJsonSchema({
 });
 ```
 
+## Caveats
+
+- Ignores the JSONSchema type `null`, since it is not directly translatable to GraphQL.
+- Ignores `allOf` and `oneOf`, since their logic is not translatable. However, `anyOf` is supported.
+
 ## Running the build
 
 To build this module use [roboter](https://www.npmjs.com/package/roboter).

--- a/README.md
+++ b/README.md
@@ -70,26 +70,28 @@ const { typeName, typeDefinitions } = getGraphqlFromJsonSchema({
 });
 
 console.log(typeName);
-// => Person
+// => PersonT0
 
 console.log(typeDefinitions);
 // => [
-//      'type PersonCoordinates {
+//      'type PersonT0CoordinatesT0 {
 //        latitude: Float!
 //        longitude: Float!
 //      }',
-//      'type PersonTags {
+//      'type PersonT0TagsT0T0 {
 //        key: String!
 //        value: String!
 //      }',
-//      'type Person {
+//      'type PersonT0 {
 //        firstName: String!
 //        lastName: String
-//        coordinates: PersonCoordinates
-//        tags: [PersonTags]!
+//        coordinates: PersonT0CoordinatesT0
+//        tags: [PersonT0TagsT0T0]!
 //      }'
 //    ]
 ```
+
+The `T0` suffixes are due to enumerating the types in each schema. If a schema has multiple types, they are noted with increasing indexes, to differentiate them in resulting union types. This also happens with `anyOf` constructs.
 
 If you want to use the generated types as input types for a mutation, additionally provide the `direction` option to the call to `getGraphqlFromJsonSchema` and set its value to `input`:
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ const { typeName, typeDefinitions } = getGraphqlFromJsonSchema({
 });
 ```
 
-## Caveats
+### Knowing the limitations
 
-- Ignores the JSONSchema type `null`, since it is not directly translatable to GraphQL.
-- Ignores `allOf` and `oneOf`, since their logic is not translatable. However, `anyOf` is supported.
+Unfortunately, it is not possible to map every aspect of a JSON schema to a GraphQL schema. When using `getGraphqlFromJsonSchema`, the following limitations apply:
+
+- The `null` type gets ignored, since it can not be mapped to GraphQL directly.
+- The keywords `allOf` and `oneOf` get ignored, since their logic can not be mapped to GraphQL. However, the `anyOf` keyword is supported.
 
 ## Running the build
 

--- a/lib/handleObjectType.ts
+++ b/lib/handleObjectType.ts
@@ -20,15 +20,7 @@ const handleObjectType = function ({ path, schema, direction }: {
   const graphqlTypeName = toPascalCase(path);
   const graphqlTypeDefinitions: string[] = [];
 
-  let currentGraphqlTypeDefinition = '';
-
-  if (direction === 'input') {
-    currentGraphqlTypeDefinition += 'input';
-  } else {
-    currentGraphqlTypeDefinition += 'type';
-  }
-
-  currentGraphqlTypeDefinition += ` ${graphqlTypeName} {\n`;
+  const lines = [];
 
   for (const [ propertyName, propertySchema ] of Object.entries(schema.properties)) {
     const isRequired = (
@@ -44,18 +36,37 @@ const handleObjectType = function ({ path, schema, direction }: {
       direction
     });
 
-    currentGraphqlTypeDefinition += `  ${propertyName}: ${propertyGraphqlTypeName}`;
+    let line = `  ${propertyName}: ${propertyGraphqlTypeName}`;
 
     if (isRequired) {
-      currentGraphqlTypeDefinition += '!\n';
+      line += '!\n';
     } else {
-      currentGraphqlTypeDefinition += '\n';
+      line += '\n';
     }
 
+    lines.push(line);
     graphqlTypeDefinitions.push(...propertyGraphqlTypeDefinitions);
   }
 
-  currentGraphqlTypeDefinition += '}';
+  let currentGraphqlTypeDefinition = '';
+
+  if (direction === 'input') {
+    currentGraphqlTypeDefinition += 'input';
+  } else {
+    currentGraphqlTypeDefinition += 'type';
+  }
+
+  if (lines.length > 0) {
+    currentGraphqlTypeDefinition += ` ${graphqlTypeName} {\n`;
+
+    for (const line of lines) {
+      currentGraphqlTypeDefinition += line;
+    }
+
+    currentGraphqlTypeDefinition += '}';
+  } else {
+    currentGraphqlTypeDefinition += ` ${graphqlTypeName}`;
+  }
 
   graphqlTypeDefinitions.push(currentGraphqlTypeDefinition);
 

--- a/lib/parseAnyOf.ts
+++ b/lib/parseAnyOf.ts
@@ -20,7 +20,7 @@ const parseAnyOf = function ({ path, schema, direction }: {
         graphqlTypeNames: string[] = [];
 
   schema.anyOf.forEach((subSchema, index): void => {
-    const result = parseSchema({ schema: subSchema, direction, path: [ ...path, String(index) ]});
+    const result = parseSchema({ schema: subSchema, direction, path: [ ...path, `I${index}` ]});
 
     graphqlTypeNames.push(result.typeName);
     graphqlTypeDefinitions.push(...result.typeDefinitions);

--- a/lib/parseAnyOf.ts
+++ b/lib/parseAnyOf.ts
@@ -1,0 +1,39 @@
+import { Direction } from './Direction';
+import { errors } from './errors';
+import { JSONSchema4 } from 'json-schema';
+import { parseSchema } from './parseSchema';
+import { toBreadcrumb } from './toBreadcrumb';
+
+const parseAnyOf = function ({ path, schema, direction }: {
+  path: string[];
+  schema: JSONSchema4;
+  direction: Direction;
+}): { typeName: string; typeDefinitions: string[] } {
+  if (!schema.anyOf) {
+    throw new errors.SchemaInvalid(`Property 'anyOf' at '${toBreadcrumb(path)}' is missing.`);
+  }
+  if (!Array.isArray(schema.anyOf)) {
+    throw new errors.SchemaInvalid(`Property 'anyOf' at '${toBreadcrumb(path)}' should be an array.`);
+  }
+
+  const graphqlTypeDefinitions: string[] = [],
+        graphqlTypeNames: string[] = [];
+
+  schema.anyOf.forEach((subSchema, index): void => {
+    const result = parseSchema({ schema: subSchema, direction, path: [ ...path, String(index) ]});
+
+    graphqlTypeNames.push(result.typeName);
+    graphqlTypeDefinitions.push(...result.typeDefinitions);
+  });
+
+  const graphqlTypeName = graphqlTypeNames.
+    filter((name): boolean => name.trim() !== '').
+    join(' | ');
+
+  return {
+    typeName: graphqlTypeName,
+    typeDefinitions: graphqlTypeDefinitions
+  };
+};
+
+export { parseAnyOf };

--- a/lib/parseSchema.ts
+++ b/lib/parseSchema.ts
@@ -1,12 +1,8 @@
 import { Direction } from './Direction';
 import { errors } from './errors';
-import { handleArrayType } from './handleArrayType';
-import { handleObjectType } from './handleObjectType';
-import { handleScalarType } from './handleScalarType';
-import { isArrayType } from './isArrayType';
-import { isObjectType } from './isObjectType';
-import { isScalarType } from './isScalarType';
 import { JSONSchema4 } from 'json-schema';
+import { parseAnyOf } from './parseAnyOf';
+import { parseType } from './parseType';
 import { toBreadcrumb } from './toBreadcrumb';
 
 const parseSchema = function ({ path, schema, direction }: {
@@ -14,38 +10,13 @@ const parseSchema = function ({ path, schema, direction }: {
   schema: JSONSchema4;
   direction: Direction;
 }): { typeName: string; typeDefinitions: string[] } {
-  if (!schema.type) {
-    throw new errors.SchemaInvalid(`Property 'type' at '${toBreadcrumb(path)}' is missing.`);
+  if (schema.type) {
+    return parseType({ path, schema, direction });
   }
-
-  const jsonTypes: string[] = [ schema.type ].flat();
-
-  const graphqlTypeNames: string[] = [];
-  const graphqlTypeDefinitions: string[] = [];
-
-  for (const jsonType of jsonTypes) {
-    let result;
-
-    if (isScalarType({ type: jsonType })) {
-      result = handleScalarType({ type: jsonType });
-    } else if (isArrayType({ type: jsonType })) {
-      result = handleArrayType({ path, schema, direction });
-    } else if (isObjectType({ type: jsonType })) {
-      result = handleObjectType({ path, schema, direction });
-    } else {
-      throw new errors.TypeInvalid(`Type '${jsonType}' at '${path}' is invalid.`);
-    }
-
-    graphqlTypeNames.push(result.typeName);
-    graphqlTypeDefinitions.push(...result.typeDefinitions);
+  if (schema.anyOf) {
+    return parseAnyOf({ path, schema, direction });
   }
-
-  const graphqlTypeName = graphqlTypeNames.join(' | ');
-
-  return {
-    typeName: graphqlTypeName,
-    typeDefinitions: graphqlTypeDefinitions
-  };
+  throw new errors.SchemaInvalid(`Structure at '${toBreadcrumb(path)}' not recognized.`);
 };
 
 export { parseSchema };

--- a/lib/parseType.ts
+++ b/lib/parseType.ts
@@ -23,24 +23,26 @@ const parseType = function ({ path, schema, direction }: {
   const graphqlTypeNames: string[] = [];
   const graphqlTypeDefinitions: string[] = [];
 
-  for (const jsonType of jsonTypes) {
+  jsonTypes.forEach((jsonType, index): void => {
     let result;
+
+    const subPath = [ ...path, `T${index}` ];
 
     if (isScalarType({ type: jsonType })) {
       result = handleScalarType({ type: jsonType });
     } else if (isArrayType({ type: jsonType })) {
-      result = handleArrayType({ path, schema, direction });
+      result = handleArrayType({ path: subPath, schema, direction });
     } else if (isObjectType({ type: jsonType })) {
-      result = handleObjectType({ path, schema, direction });
+      result = handleObjectType({ path: subPath, schema, direction });
     } else if (jsonType === 'null') {
-      continue;
+      return;
     } else {
       throw new errors.TypeInvalid(`Type '${jsonType}' at '${path}' is invalid.`);
     }
 
     graphqlTypeNames.push(result.typeName);
     graphqlTypeDefinitions.push(...result.typeDefinitions);
-  }
+  });
 
   const graphqlTypeName = graphqlTypeNames.
     filter((name): boolean => name.trim() !== '').

--- a/lib/parseType.ts
+++ b/lib/parseType.ts
@@ -1,0 +1,55 @@
+import { Direction } from './Direction';
+import { errors } from './errors';
+import { handleArrayType } from './handleArrayType';
+import { handleObjectType } from './handleObjectType';
+import { handleScalarType } from './handleScalarType';
+import { isArrayType } from './isArrayType';
+import { isObjectType } from './isObjectType';
+import { isScalarType } from './isScalarType';
+import { JSONSchema4 } from 'json-schema';
+import { toBreadcrumb } from './toBreadcrumb';
+
+const parseType = function ({ path, schema, direction }: {
+  path: string[];
+  schema: JSONSchema4;
+  direction: Direction;
+}): { typeName: string; typeDefinitions: string[] } {
+  if (!schema.type) {
+    throw new errors.SchemaInvalid(`Property 'type' at '${toBreadcrumb(path)}' is missing.`);
+  }
+
+  const jsonTypes: string[] = [ schema.type ].flat();
+
+  const graphqlTypeNames: string[] = [];
+  const graphqlTypeDefinitions: string[] = [];
+
+  for (const jsonType of jsonTypes) {
+    let result;
+
+    if (isScalarType({ type: jsonType })) {
+      result = handleScalarType({ type: jsonType });
+    } else if (isArrayType({ type: jsonType })) {
+      result = handleArrayType({ path, schema, direction });
+    } else if (isObjectType({ type: jsonType })) {
+      result = handleObjectType({ path, schema, direction });
+    } else if (jsonType === 'null') {
+      continue;
+    } else {
+      throw new errors.TypeInvalid(`Type '${jsonType}' at '${path}' is invalid.`);
+    }
+
+    graphqlTypeNames.push(result.typeName);
+    graphqlTypeDefinitions.push(...result.typeDefinitions);
+  }
+
+  const graphqlTypeName = graphqlTypeNames.
+    filter((name): boolean => name.trim() !== '').
+    join(' | ');
+
+  return {
+    typeName: graphqlTypeName,
+    typeDefinitions: graphqlTypeDefinitions
+  };
+};
+
+export { parseType };

--- a/test/unit/getGraphqlFromJsonSchemaTests.ts
+++ b/test/unit/getGraphqlFromJsonSchemaTests.ts
@@ -227,6 +227,24 @@ suite('getGraphqlFromJsonSchema', (): void => {
           }`
       ]);
     });
+
+    test('renders empty types correctly.', async (): Promise<void> => {
+      const { typeName, typeDefinitions } = getGraphqlFromJsonSchema({
+        rootName: 'foo',
+        schema: {
+          type: 'object',
+          properties: {},
+          additionalProperties: false
+        }
+      });
+
+      assert.that(typeName).is.equalTo('Foo');
+      assert.that(typeDefinitions).is.equalTo([
+        stripIndent`
+          type Foo
+        `
+      ]);
+    });
   });
 
   suite('schemas with anyOf', (): void => {


### PR DESCRIPTION
Hi @goloroden,

I've added support for `anyOf`. I've also changed the type handling to ignore the JSONSchema type `null`.

I thought about using `null` inside an `anyOf` to make a property optional, but that is complicated and might conflict with the schema's intention. Ignoring `null`s is the most consistent way I can think of so far.