### PR TITLE
fix: runtime deps are in dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   "main": "build/lib/getGraphqlFromJsonSchema.js",
   "types": "build/lib/getGraphqlFromJsonSchema.d.ts",
   "dependencies": {
+    "@types/common-tags": "1.8.0",
+    "@types/json-schema": "7.0.4",
+    "common-tags": "1.8.0",
     "defekt": "5.0.1"
   },
   "devDependencies": {
-    "@types/common-tags": "1.8.0",
-    "@types/json-schema": "7.0.4",
     "assertthat": "5.1.1",
-    "common-tags": "1.8.0",
     "roboter": "11.1.23",
     "semantic-release-configuration": "1.0.19"
   },


### PR DESCRIPTION
Guten Tag Native Web Team,
thank you for making that great tool.

After installing this module and using the function, I got an error because some dependencies are in `devDependencies` but should be in `dependencies`.

For example `common-tags` is used in [parseSchema.ts](https://github.com/thenativeweb/get-graphql-from-jsonschema/blob/master/lib/parseSchema.ts#L6) but will not be installed with `npm install get-graphql-from-jsonschema`

Also I moved the `@types/*` dependencies from dev to prod. These are also needed upwards.

I analysed you CI and found that `roboter deps` does not catch this error. I recommend also adding [dependency-check](https://www.npmjs.com/package/dependency-check) to prevent this problem in the future.