### PR TITLE
feat: Flip usage of oneOf/anyOf, since it was wrong. Add documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,50 @@ const { typeName, typeDefinitions } = getGraphqlFromJsonSchema({
 });
 ```
 
+### Using `oneOf` to generate union types
+
+The `oneOf` keyword is supported with a limitation on its use: There must be no other properties on the same level as the `oneOf`.
+
+```javascript
+const { typeName, typeDefinitions } = getGraphqlFromJsonSchema({
+  rootName: 'foobar',
+  schema: {
+    oneOf: [
+      {
+        type: 'number'
+      },
+      {
+        type: 'object',
+        properties: {
+          foo: { type: 'string' },
+          bar: { type: 'number' }
+        },
+        required: [ 'foo' ],
+        additionalProperties: false
+      }
+    ]
+  }
+});
+
+console.log(typeName);
+// => Foobar
+
+console.log(typeDefinitions);
+// => [
+//     'type FoobarI1T0 {
+//       foo: String!
+//       bar: Float
+//     }',
+//     'union Foobar = Float | FoobarI1T0'
+// ]
+```
+
 ### Knowing the limitations
 
 Unfortunately, it is not possible to map every aspect of a JSON schema to a GraphQL schema. When using `getGraphqlFromJsonSchema`, the following limitations apply:
 
 - The `null` type gets ignored, since it can not be mapped to GraphQL directly.
-- The keywords `allOf` and `oneOf` get ignored, since their logic can not be mapped to GraphQL. However, the `anyOf` keyword is supported.
+- The keywords `allOf` and `anyOf` get ignored, since their logic can not be mapped to GraphQL. However, the `oneOf` keyword is supported.
 
 ## Running the build
 

--- a/lib/parseOneOf.ts
+++ b/lib/parseOneOf.ts
@@ -4,22 +4,22 @@ import { JSONSchema4 } from 'json-schema';
 import { parseSchema } from './parseSchema';
 import { toBreadcrumb } from './toBreadcrumb';
 
-const parseAnyOf = function ({ path, schema, direction }: {
+const parseOneOf = function ({ path, schema, direction }: {
   path: string[];
   schema: JSONSchema4;
   direction: Direction;
 }): { typeName: string; typeDefinitions: string[] } {
-  if (!schema.anyOf) {
-    throw new errors.SchemaInvalid(`Property 'anyOf' at '${toBreadcrumb(path)}' is missing.`);
+  if (!schema.oneOf) {
+    throw new errors.SchemaInvalid(`Property 'oneOf' at '${toBreadcrumb(path)}' is missing.`);
   }
-  if (!Array.isArray(schema.anyOf)) {
-    throw new errors.SchemaInvalid(`Property 'anyOf' at '${toBreadcrumb(path)}' should be an array.`);
+  if (!Array.isArray(schema.oneOf)) {
+    throw new errors.SchemaInvalid(`Property 'oneOf' at '${toBreadcrumb(path)}' should be an array.`);
   }
 
   const graphqlTypeDefinitions: string[] = [],
         graphqlTypeNames: string[] = [];
 
-  schema.anyOf.forEach((subSchema, index): void => {
+  schema.oneOf.forEach((subSchema, index): void => {
     const result = parseSchema({ schema: subSchema, direction, path: [ ...path, `I${index}` ]});
 
     graphqlTypeNames.push(result.typeName);
@@ -36,4 +36,4 @@ const parseAnyOf = function ({ path, schema, direction }: {
   };
 };
 
-export { parseAnyOf };
+export { parseOneOf };

--- a/lib/parseSchema.ts
+++ b/lib/parseSchema.ts
@@ -1,7 +1,7 @@
 import { Direction } from './Direction';
 import { errors } from './errors';
 import { JSONSchema4 } from 'json-schema';
-import { parseAnyOf } from './parseAnyOf';
+import { parseOneOf } from './parseOneOf';
 import { parseType } from './parseType';
 import { stripIndent } from 'common-tags';
 import { toBreadcrumb } from './toBreadcrumb';
@@ -16,8 +16,8 @@ const parseSchema = function ({ path, schema, direction }: {
 
   if (schema.type) {
     result = parseType({ path, schema, direction });
-  } else if (schema.anyOf) {
-    result = parseAnyOf({ path, schema, direction });
+  } else if (schema.oneOf) {
+    result = parseOneOf({ path, schema, direction });
   } else {
     throw new errors.SchemaInvalid(`Structure at '${toBreadcrumb(path)}' not recognized.`);
   }

--- a/test/unit/getGraphqlFromJsonSchemaTests.ts
+++ b/test/unit/getGraphqlFromJsonSchemaTests.ts
@@ -278,12 +278,12 @@ suite('getGraphqlFromJsonSchema', (): void => {
     });
   });
 
-  suite('schemas with anyOf', (): void => {
-    test('returns a union type for anyOf types.', async (): Promise<void> => {
+  suite('schemas with oneOf', (): void => {
+    test('returns a union type for oneOf types.', async (): Promise<void> => {
       const { typeName, typeDefinitions } = getGraphqlFromJsonSchema({
         rootName: 'foobar',
         schema: {
-          anyOf: [
+          oneOf: [
             {
               type: 'number'
             },
@@ -321,7 +321,7 @@ suite('getGraphqlFromJsonSchema', (): void => {
           type: 'object',
           properties: {
             foo: {
-              anyOf: [
+              oneOf: [
                 { type: 'number', minimum: 1 },
                 { type: 'null' }
               ]


### PR DESCRIPTION
BREAKING CHANGE:
It is impossible to map json schema's anyOf to GraphQL, since multiple
of the given schemas may match. GraphQL only provider exclusionary
union types, which correspond to oneOf in json schema.
So the terms had to be switched.
