### PR TITLE
feat: Migrate to JSONSchema7.

### DIFF
--- a/lib/getGraphqlFromJsonSchema.ts
+++ b/lib/getGraphqlFromJsonSchema.ts
@@ -1,10 +1,10 @@
 import { Direction } from './Direction';
-import { JSONSchema4 } from 'json-schema';
+import { JSONSchema7 } from 'json-schema';
 import { parseSchema } from './parseSchema';
 
 const getGraphqlFromJsonSchema = function ({ rootName, schema, direction = 'output' }: {
   rootName: string;
-  schema: JSONSchema4;
+  schema: JSONSchema7;
   direction?: Direction;
 }): { typeName: string; typeDefinitions: string[] } {
   return parseSchema({ path: [ rootName ], schema, direction });

--- a/lib/handleArrayType.ts
+++ b/lib/handleArrayType.ts
@@ -1,12 +1,12 @@
 import { Direction } from './Direction';
 import { errors } from './errors';
-import { JSONSchema4 } from 'json-schema';
+import { JSONSchema7 } from 'json-schema';
 import { parseSchema } from './parseSchema';
 import { toBreadcrumb } from './toBreadcrumb';
 
 const handleArrayType = function ({ path, schema, direction }: {
   path: string[];
-  schema: JSONSchema4;
+  schema: JSONSchema7;
   direction: Direction;
 }): { typeName: string; typeDefinitions: string[] } {
   if (!schema.items) {
@@ -19,7 +19,7 @@ const handleArrayType = function ({ path, schema, direction }: {
   const {
     typeName: graphqlTypeName,
     typeDefinitions: graphqlTypeDefinitions
-  } = parseSchema({ path, schema: schema.items, direction });
+  } = parseSchema({ path, schema: schema.items as JSONSchema7, direction });
 
   return {
     typeName: `[${graphqlTypeName}]`,

--- a/lib/handleObjectType.ts
+++ b/lib/handleObjectType.ts
@@ -1,13 +1,13 @@
 import { Direction } from './Direction';
 import { errors } from './errors';
-import { JSONSchema4 } from 'json-schema';
+import { JSONSchema7 } from 'json-schema';
 import { parseSchema } from './parseSchema';
 import { toBreadcrumb } from './toBreadcrumb';
 import { toPascalCase } from './toPascalCase';
 
 const handleObjectType = function ({ path, schema, direction }: {
   path: string[];
-  schema: JSONSchema4;
+  schema: JSONSchema7;
   direction: Direction;
 }): { typeName: string; typeDefinitions: string[] } {
   if (!schema.properties) {
@@ -32,7 +32,7 @@ const handleObjectType = function ({ path, schema, direction }: {
       typeDefinitions: propertyGraphqlTypeDefinitions
     } = parseSchema({
       path: [ ...path, propertyName ],
-      schema: propertySchema,
+      schema: propertySchema as JSONSchema7,
       direction
     });
 

--- a/lib/parseOneOf.ts
+++ b/lib/parseOneOf.ts
@@ -1,12 +1,12 @@
 import { Direction } from './Direction';
 import { errors } from './errors';
-import { JSONSchema4 } from 'json-schema';
+import { JSONSchema7 } from 'json-schema';
 import { parseSchema } from './parseSchema';
 import { toBreadcrumb } from './toBreadcrumb';
 
 const parseOneOf = function ({ path, schema, direction }: {
   path: string[];
-  schema: JSONSchema4;
+  schema: JSONSchema7;
   direction: Direction;
 }): { typeName: string; typeDefinitions: string[] } {
   if (!schema.oneOf) {
@@ -20,7 +20,7 @@ const parseOneOf = function ({ path, schema, direction }: {
         graphqlTypeNames: string[] = [];
 
   schema.oneOf.forEach((subSchema, index): void => {
-    const result = parseSchema({ schema: subSchema, direction, path: [ ...path, `I${index}` ]});
+    const result = parseSchema({ schema: subSchema as JSONSchema7, direction, path: [ ...path, `I${index}` ]});
 
     graphqlTypeNames.push(result.typeName);
     graphqlTypeDefinitions.push(...result.typeDefinitions);

--- a/lib/parseSchema.ts
+++ b/lib/parseSchema.ts
@@ -1,6 +1,6 @@
 import { Direction } from './Direction';
 import { errors } from './errors';
-import { JSONSchema4 } from 'json-schema';
+import { JSONSchema7 } from 'json-schema';
 import { parseOneOf } from './parseOneOf';
 import { parseType } from './parseType';
 import { stripIndent } from 'common-tags';
@@ -9,7 +9,7 @@ import { toPascalCase } from './toPascalCase';
 
 const parseSchema = function ({ path, schema, direction }: {
   path: string[];
-  schema: JSONSchema4;
+  schema: JSONSchema7;
   direction: Direction;
 }): { typeName: string; typeDefinitions: string[] } {
   let result: { typeName: string; typeDefinitions: string[] };

--- a/lib/parseType.ts
+++ b/lib/parseType.ts
@@ -6,12 +6,12 @@ import { handleScalarType } from './handleScalarType';
 import { isArrayType } from './isArrayType';
 import { isObjectType } from './isObjectType';
 import { isScalarType } from './isScalarType';
-import { JSONSchema4 } from 'json-schema';
+import { JSONSchema7 } from 'json-schema';
 import { toBreadcrumb } from './toBreadcrumb';
 
 const parseType = function ({ path, schema, direction }: {
   path: string[];
-  schema: JSONSchema4;
+  schema: JSONSchema7;
   direction: Direction;
 }): { typeName: string; typeDefinitions: string[] } {
   if (!schema.type) {


### PR DESCRIPTION
BREAKING CHANGE:

Types are new incompatible with the previously used JSONSchema4 type.
