### PR TITLE
fix: update defekt

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,8 +1,9 @@
 import { defekt } from 'defekt';
 
-const errors = defekt({
-  SchemaInvalid: {},
-  TypeInvalid: {}
-});
+class SchemaInvalid extends defekt({ code: 'SchemaInvalid' }) {}
+class TypeInvalid extends defekt({ code: 'TypeInvalid' }) {}
 
-export { errors };
+export {
+  SchemaInvalid,
+  TypeInvalid
+};

--- a/lib/handleArrayType.ts
+++ b/lib/handleArrayType.ts
@@ -1,8 +1,8 @@
 import { Direction } from './Direction';
-import { errors } from './errors';
 import { JSONSchema7 } from 'json-schema';
 import { parseSchema } from './parseSchema';
 import { toBreadcrumb } from './toBreadcrumb';
+import * as errors from './errors';
 
 const handleArrayType = function ({ path, schema, direction }: {
   path: string[];

--- a/lib/handleObjectType.ts
+++ b/lib/handleObjectType.ts
@@ -1,9 +1,9 @@
 import { Direction } from './Direction';
-import { errors } from './errors';
 import { JSONSchema7 } from 'json-schema';
 import { parseSchema } from './parseSchema';
 import { toBreadcrumb } from './toBreadcrumb';
 import { toPascalCase } from './toPascalCase';
+import * as errors from './errors';
 
 const handleObjectType = function ({ path, schema, direction }: {
   path: string[];

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,7 @@
+import { getGraphqlFromJsonSchema } from './getGraphqlFromJsonSchema';
+import * as errors from './errors';
+
+export {
+  errors,
+  getGraphqlFromJsonSchema
+};

--- a/lib/parseOneOf.ts
+++ b/lib/parseOneOf.ts
@@ -1,8 +1,8 @@
 import { Direction } from './Direction';
-import { errors } from './errors';
 import { JSONSchema7 } from 'json-schema';
 import { parseSchema } from './parseSchema';
 import { toBreadcrumb } from './toBreadcrumb';
+import * as errors from './errors';
 
 const parseOneOf = function ({ path, schema, direction }: {
   path: string[];

--- a/lib/parseSchema.ts
+++ b/lib/parseSchema.ts
@@ -1,11 +1,11 @@
 import { Direction } from './Direction';
-import { errors } from './errors';
 import { JSONSchema7 } from 'json-schema';
 import { parseOneOf } from './parseOneOf';
 import { parseType } from './parseType';
 import { stripIndent } from 'common-tags';
 import { toBreadcrumb } from './toBreadcrumb';
 import { toPascalCase } from './toPascalCase';
+import * as errors from './errors';
 
 const parseSchema = function ({ path, schema, direction }: {
   path: string[];

--- a/lib/parseType.ts
+++ b/lib/parseType.ts
@@ -1,5 +1,4 @@
 import { Direction } from './Direction';
-import { errors } from './errors';
 import { handleArrayType } from './handleArrayType';
 import { handleObjectType } from './handleObjectType';
 import { handleScalarType } from './handleScalarType';
@@ -8,6 +7,7 @@ import { isObjectType } from './isObjectType';
 import { isScalarType } from './isScalarType';
 import { JSONSchema7 } from 'json-schema';
 import { toBreadcrumb } from './toBreadcrumb';
+import * as errors from './errors';
 
 const parseType = function ({ path, schema, direction }: {
   path: string[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -2081,9 +2081,9 @@
       }
     },
     "defekt": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/defekt/-/defekt-6.0.2.tgz",
-      "integrity": "sha512-pMXTtCbb3OpKnf3McYwUFERjWQ2siu1oT5T25WljaB4/aRGvhL9IWYmYJ6T5DrvNUhNxxCfuARJ5g4nDmp6jNA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/defekt/-/defekt-7.0.4.tgz",
+      "integrity": "sha512-6+70JzdjQigN9WHFWrWgQGcbpn0YsTUj7moJBBX+3gMeWUnavnK0aOTD5IMOkPAy+emPETtn1//3WyT5aO4XzQ=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -8833,6 +8833,12 @@
         "typescript": "4.2.3"
       },
       "dependencies": {
+        "defekt": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/defekt/-/defekt-6.0.2.tgz",
+          "integrity": "sha512-pMXTtCbb3OpKnf3McYwUFERjWQ2siu1oT5T25WljaB4/aRGvhL9IWYmYJ6T5DrvNUhNxxCfuARJ5g4nDmp6jNA==",
+          "dev": true
+        },
         "globby": {
           "version": "11.0.3",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/common-tags": "1.8.0",
     "@types/json-schema": "7.0.7",
     "common-tags": "1.8.0",
-    "defekt": "6.0.2"
+    "defekt": "7.0.4"
   },
   "devDependencies": {
     "assertthat": "5.2.6",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     {
       "name": "Hannes Leutloff",
       "email": "hannes.leutloff@thenativeweb.io"
+    },
+    {
+      "name": "Noah Hummel",
+      "email": "noah.hummel@thenativeweb.io"
     }
   ],
-  "main": "build/lib/getGraphqlFromJsonSchema.js",
-  "types": "build/lib/getGraphqlFromJsonSchema.d.ts",
+  "main": "build/lib/index.js",
+  "types": "build/lib/index.d.ts",
   "dependencies": {
     "@types/common-tags": "1.8.0",
     "@types/json-schema": "7.0.7",


### PR DESCRIPTION
BREAKING CHANGE

The errors thrown by the library have changed, if you relied on their error codes before, you have to use the exported errors.