### PR TITLE
ADD sideEffects:false for proper tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "private": false,
   "main": "build/lib/index.js",
   "types": "build/lib/index.d.ts",
+  "sideEffects": false,
   "dependencies": {
     "@types/common-tags": "1.8.1",
     "@types/json-schema": "7.0.9",


### PR DESCRIPTION
I noticed that this module causes optimization bailouts when bundled with webpack.
I think the best way is to set `sideEffects: false` like described [here](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).
This makes sure that webpack knows that this module has no side effects. So when the module is imported/exported, but no method of it is used, webpack can strip it from the build output.

At the moment, this module and its dependencies are bundled into a default angular application, even when the functions are not used.
<img src="https://user-images.githubusercontent.com/8926560/142174206-f070b7df-fe8f-4b74-93e9-0059682d3298.png" alt="bundle size" width="400" />.